### PR TITLE
Add options to allow lit to be used in a pipe

### DIFF
--- a/src/Html.hs
+++ b/src/Html.hs
@@ -15,10 +15,10 @@ import Cheapskate.Html
 import Highlight
 import Types
 
-generate :: Maybe String -> String -> [Chunk] -> T.Text
-generate maybeCss name chunks = 
+generate :: Maybe String -> Maybe String -> String -> [Chunk] -> T.Text
+generate maybeCss maybeLang name chunks = 
     let 
-        lang = getLang name
+        lang = fromMaybe (getLang name) maybeLang
         mergedProse = simplify chunks -- adjacent Prose combined to one prose
         body = H.preEscapedToHtml $ map (chunkToHtml lang) mergedProse
         doc = preface maybeCss name body

--- a/src/Html.hs.lit
+++ b/src/Html.hs.lit
@@ -44,10 +44,10 @@ before calling `generate` to make the Html file from a `lit` file. It performs t
 2. [Convert](#transform_a_chunk_to_html) each `Chunk` to html
 3. [Preface](#preface_the_html_with_the_head_tag) the html with proper Doctype/Head/Meta
     << generate html document from chunks >>=
-    generate :: Maybe String -> String -> [Chunk] -> T.Text
-    generate maybeCss name chunks = 
+    generate :: Maybe String -> Maybe String -> String -> [Chunk] -> T.Text
+    generate maybeCss maybeLang name chunks = 
         let 
-            lang = getLang name
+            lang = fromMaybe (getLang name) maybeLang
             mergedProse = simplify chunks -- adjacent Prose combined to one prose
             body = H.preEscapedToHtml $ map (chunkToHtml lang) mergedProse
             doc = preface maybeCss name body

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -1,15 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Markdown ( generate ) where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 
 import Types
 import Highlight (getLang)
 
-generate :: String -> [Chunk] -> T.Text
-generate name chunks = 
+generate :: Maybe String -> String -> [Chunk] -> T.Text
+generate maybeLang name chunks = 
     let 
-        lang = getLang name
+        lang = fromMaybe (getLang name) maybeLang
         toMarkDown = chunkToMarkdown lang
     in
         T.concat $ map toMarkDown chunks

--- a/src/Markdown.hs.lit
+++ b/src/Markdown.hs.lit
@@ -23,6 +23,7 @@ Markdown only exports `generate` akin to Code and Html, the other output modules
 Markdown performs little processing and as a result has light dependencies. 
 In Markdown, `getLang` is used to to label code blocks with a language.
     << import modules >>=
+    import Data.Maybe (fromMaybe)
     import qualified Data.Text as T
 
     import Types
@@ -32,10 +33,10 @@ In Markdown, `getLang` is used to to label code blocks with a language.
 before calling `generate` to make the markdown file from a `lit` file. `generate` returns
 the union of all the transformed markdown `Chunk`s.
     << generate markdown document from chunks >>=
-    generate :: String -> [Chunk] -> T.Text
-    generate name chunks = 
+    generate :: Maybe String -> String -> [Chunk] -> T.Text
+    generate maybeLang name chunks = 
         let 
-            lang = getLang name
+            lang = fromMaybe (getLang name) maybeLang
             toMarkDown = chunkToMarkdown lang
         in
             T.concat $ map toMarkDown chunks

--- a/src/Process.hs
+++ b/src/Process.hs
@@ -36,18 +36,18 @@ processString writeOutput input fileName pipes = do
     encoded <- return $ encode input
     mapM_ (\f -> f fileName encoded writeOutput) pipes >> return ()
 
-htmlPipeline dir mCss name enc writeOutput = do
+htmlPipeline dir mCss mLang name enc writeOutput = do
     maybeCss <- cssRelativeToOutput dir mCss
     let path = (addTrailingPathSeparator dir) ++ name ++ ".html"
-        output = Html.generate maybeCss name enc
+        output = Html.generate maybeCss mLang name enc
     writeOutput path output
 
-mdPipeline dir css name enc writeOutput = writeOutput path output
+mdPipeline dir css mLang name enc writeOutput = writeOutput path output
     where
         path = (addTrailingPathSeparator dir) ++ name ++ ".md"
-        output = Markdown.generate name enc
+        output = Markdown.generate mLang name enc
 
-codePipeline dir css name enc writeOutput = writeOutput path output
+codePipeline dir css mLang name enc writeOutput = writeOutput path output
     where
         path = (addTrailingPathSeparator dir) ++ name
         output = Code.generate enc

--- a/src/Process.hs.lit
+++ b/src/Process.hs.lit
@@ -80,20 +80,20 @@ Beside the main function `process`. Process as a module defines several useful p
     << html helpers >>
 
     << html pipeline >>=
-    htmlPipeline dir mCss name enc writeOutput = do
+    htmlPipeline dir mCss mLang name enc writeOutput = do
         maybeCss <- cssRelativeToOutput dir mCss
         let path = (addTrailingPathSeparator dir) ++ name ++ ".html"
-            output = Html.generate maybeCss name enc
+            output = Html.generate maybeCss mLang name enc
         writeOutput path output
 
     << markdown pipeline >>=
-    mdPipeline dir css name enc writeOutput = writeOutput path output
+    mdPipeline dir css mLang name enc writeOutput = writeOutput path output
         where
             path = (addTrailingPathSeparator dir) ++ name ++ ".md"
-            output = Markdown.generate name enc
+            output = Markdown.generate mLang name enc
 
     << code pipeline >>=
-    codePipeline dir css name enc writeOutput = writeOutput path output
+    codePipeline dir css mLang name enc writeOutput = writeOutput path output
         where
             path = (addTrailingPathSeparator dir) ++ name
             output = Code.generate enc

--- a/src/Process.hs.lit
+++ b/src/Process.hs.lit
@@ -11,6 +11,8 @@ An overview of the file:
     << define Process module >>
     << import modules >>
     << process a single file >>
+    << process stdin to stdout >>
+    << process a string >>
     << helper functions >>
 
 Process exports the pipelines so they can be *preconfigured*. In `lit.hs`, the pipelines are curried with the output directory corresponding to their type, and with the optional css path. The `process` function depends on being called with preconfigured pipes.     
@@ -18,14 +20,15 @@ Process exports the pipelines so they can be *preconfigured*. In `lit.hs`, the p
     {-# LANGUAGE OverloadedStrings #-}
     module Process
     ( process
+    , processPipe
     , htmlPipeline
     , mdPipeline
     , codePipeline ) where
 
 Besides the reading and writing file utilities, each output format is contained in a module which specifies a `generate` function. Ex. `Html.generate` renders the parsed `.lit` file as `Text`.
     << import modules >>=
-    import Prelude hiding (readFile, writeFile)
-    import Data.Text.IO (writeFile, readFile)
+    import Prelude hiding (readFile, writeFile, getContents, putStr)
+    import Data.Text.IO (writeFile, readFile, getContents, putStr)
     import System.FilePath.Posix (takeFileName, dropExtension)
     import System.Directory
     import System.FilePath.Posix
@@ -38,14 +41,31 @@ Besides the reading and writing file utilities, each output format is contained 
     import Markdown
     import Types
 
-Process as a library accompolishes the primary goals through the `process` function. After reading the file, `encode` parses the file into `[Chunks]` (see [Types.hs](Types.hs.html) for more about the data structure). Lastly, each pipeline function in the list of `pipes` is applied to the data structure. Each pipeline takes a `[Chunks]` and writes a file. 
+Process as a library accompolishes the primary goals through the `processString` function. The input string is passed to `encode`, which parses it into `[Chunks]` (see [Types.hs](Types.hs.html) for more about the data structure). Lastly, each pipeline function in the list of `pipes` is applied to the data structure. Each pipeline takes a `[Chunks]` and calls the `writeOutput` function, specifying the desired filename and the processed text.
+    << process a string >>=
+    processString writeOutput input fileName pipes = do
+        encoded <- return $ encode input
+        mapM_ (\f -> f fileName encoded writeOutput) pipes >> return ()
+
+The most common way to call `processString` is with a file. The file contents is
+read and processed, then the output is written to the file specified by the
+processor (using the `writeFile` function from `Data.Text.IO`).
     << process a single file >>=
-    process pipes file = do 
+    process pipes file = do
         stream <- readFile file
-        encoded <- return $ encode stream 
-        mapM_ (\f -> f fileName encoded) pipes >> return ()
+        processString writeFile stream fileName pipes >> return ()
         where
             fileName = dropExtension $ takeFileName file
+
+When requested `lit` will operate as a pipe processor. The processing of the
+text proceeds as in `process`, but the input comes from `stdin` and the output
+function just dumps the result to `stdout` (ignoring the requested file name).
+    << process stdin to stdout >>=
+    processPipe pipes = do
+        input <- getContents
+        processString writeStdout input "-" pipes >> return ()
+        where
+            writeStdout = (\name output -> putStr output)
 
 Beside the main function `process`. Process as a module defines several useful pipelines (function transforms chained together). Each pipeline can be generalized in the following way.
 
@@ -60,20 +80,20 @@ Beside the main function `process`. Process as a module defines several useful p
     << html helpers >>
 
     << html pipeline >>=
-    htmlPipeline dir mCss name enc = do
+    htmlPipeline dir mCss name enc writeOutput = do
         maybeCss <- cssRelativeToOutput dir mCss
         let path = (addTrailingPathSeparator dir) ++ name ++ ".html"
             output = Html.generate maybeCss name enc
-        writeFile path output
+        writeOutput path output
 
     << markdown pipeline >>=
-    mdPipeline dir css name enc = writeFile path output
+    mdPipeline dir css name enc writeOutput = writeOutput path output
         where
             path = (addTrailingPathSeparator dir) ++ name ++ ".md"
             output = Markdown.generate name enc
 
     << code pipeline >>=
-    codePipeline dir css name enc = writeFile path output
+    codePipeline dir css name enc writeOutput = writeOutput path output
         where
             path = (addTrailingPathSeparator dir) ++ name
             output = Code.generate enc

--- a/src/lit.hs.lit
+++ b/src/lit.hs.lit
@@ -40,6 +40,7 @@ A high-level overview of `lit.hs`:
                             , optMarkdown :: Bool
                             , optWatch    :: Bool
                             , optPipe     :: Bool
+                            , optLang     :: Maybe String
                             }
 
     << default options >>=
@@ -52,6 +53,7 @@ A high-level overview of `lit.hs`:
                             , optMarkdown = False
                             , optWatch    = False
                             , optPipe     = False
+                            , optLang     = Nothing
                             }
 
 `options` is a list of monadic functions, which are applied to the options passed as arguments to `lit`. `options` provides the general program flow for argument handling.
@@ -79,6 +81,12 @@ A high-level overview of `lit.hs`:
         , Option "p" ["pipe"]
            (NoArg (\opt -> return opt { optPipe = True }))
            "Process stdin and write to stdout"
+    
+        , Option "" ["lang"]
+           (ReqArg
+               (\arg opt -> return opt { optLang = Just arg })
+               "Language")
+           "Specify language to use when doing code highlighting"
     
         , Option "" ["docs-dir"]
            (ReqArg
@@ -138,6 +146,7 @@ After interpreting the arguments, `foldl` threads the default options through ea
                     , optCss      = mCss
                     , optWatch    = watching
                     , optPipe     = actAsPipe
+                    , optLang     = mLang
                     } = opts 
 
 A brief check to ensure that the directories actually exist for the given strings. This prevents ambiguous errors about writing to invalid paths.
@@ -147,9 +156,9 @@ A brief check to ensure that the directories actually exist for the given string
 
 Based on the conditions, we prepare part of the pipeline (the rest occurs in Process.hs) for generating (html/markdown/code). This block aims to gather all the pipes and program errors necessary for determining whether to process or exit. `maybeWatch` determines whether the files should be directly passed through the pipes via `mapM_` or whether `Poll.watch` should manage the pipelines whenever the underlying files change.
     << main >>=
-        let htmlPipe = if html     then [Process.htmlPipeline docsDir mCss] else []
-            mdPipe   = if markdown then [Process.mdPipeline   docsDir mCss] else []
-            codePipe = if code     then [Process.codePipeline codeDir mCss] else []
+        let htmlPipe = if html     then [Process.htmlPipeline docsDir mCss mLang] else []
+            mdPipe   = if markdown then [Process.mdPipeline   docsDir mCss mLang] else []
+            codePipe = if code     then [Process.codePipeline codeDir mCss mLang] else []
             pipes = htmlPipe ++ mdPipe ++ codePipe 
             maybeWatch = if watching then Poll.watch else mapM_
             errors'  = if codeDirCheck then [] else ["Directory: " ++ codeDir ++ " does not exist\n"]

--- a/src/lit.hs.lit
+++ b/src/lit.hs.lit
@@ -39,6 +39,7 @@ A high-level overview of `lit.hs`:
                             , optHtml     :: Bool
                             , optMarkdown :: Bool
                             , optWatch    :: Bool
+                            , optPipe     :: Bool
                             }
 
     << default options >>=
@@ -50,6 +51,7 @@ A high-level overview of `lit.hs`:
                             , optHtml     = False
                             , optMarkdown = False
                             , optWatch    = False
+                            , optPipe     = False
                             }
 
 `options` is a list of monadic functions, which are applied to the options passed as arguments to `lit`. `options` provides the general program flow for argument handling.
@@ -73,6 +75,10 @@ A high-level overview of `lit.hs`:
                (\arg opt -> return opt { optCss = Just arg })
                "FILE")
            "Specify a css file for html generation"
+    
+        , Option "p" ["pipe"]
+           (NoArg (\opt -> return opt { optPipe = True }))
+           "Process stdin and write to stdout"
     
         , Option "" ["docs-dir"]
            (ReqArg
@@ -131,6 +137,7 @@ After interpreting the arguments, `foldl` threads the default options through ea
                     , optHtml     = html
                     , optCss      = mCss
                     , optWatch    = watching
+                    , optPipe     = actAsPipe
                     } = opts 
 
 A brief check to ensure that the directories actually exist for the given strings. This prevents ambiguous errors about writing to invalid paths.
@@ -147,10 +154,16 @@ Based on the conditions, we prepare part of the pipeline (the rest occurs in Pro
             maybeWatch = if watching then Poll.watch else mapM_
             errors'  = if codeDirCheck then [] else ["Directory: " ++ codeDir ++ " does not exist\n"]
             errors'' = if docsDirCheck then [] else ["Directory: " ++ docsDir ++ " does not exist\n"]
-            allErr = errors ++ errors' ++ errors''
+            errors''' = if actAsPipe && (files /= [] || watching)
+                then ["--pipe is incompatible with --watch and input file names\n"]
+                else []
+            allErr = errors ++ errors' ++ errors'' ++ errors'''
+            processFn = if actAsPipe
+                then (\p _ -> Process.processPipe p)
+                else (\p f -> (maybeWatch (Process.process p)) f)
 
 In the final call of main, either the programs prints [errors](#usage%20messages) or redirects the program flow with `maybeWatch`. The bulk of the file processing is passed to the `Process.hs` [module](Process.hs.html).
     << main >>=
-        if allErr /= [] || (not html && not code && not markdown) || files == []
+        if allErr /= [] || (not html && not code && not markdown) || (files == [] && not actAsPipe)
             then hPutStrLn stderr ((concat allErr) ++ help) 
-            else (maybeWatch (Process.process pipes)) files
+            else processFn pipes files


### PR DESCRIPTION
I've bundled these together as they are related.

The --pipe option allows things like
```
cat a.lit b.lit | lit -c --pipe > c.c
```
and the lang option allows things like
```
cat a.lit b.lit | lit -h --lang=c --pipe > c.html
```
whilst keeping syntax highlighting.