### PR TITLE
Add support for including files and line directives in generated code

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,10 +20,10 @@ cd $lit_home
 # Generate code (src files)
 echo "● Regenerating *.hs from *.hs.lit:"
 if [ -f ./dist/build/lit/lit ]; then 
-    ./dist/build/lit/lit --code --code-dir=src/ src/*.lit || exit 1
+    ./dist/build/lit/lit -n --code --code-dir=src/ src/*.lit || exit 1
 else
     cabal configure && cabal build 
-    ./dist/build/lit/lit --code --code-dir=src/ src/*.lit || exit 1
+    ./dist/build/lit/lit -n --code --code-dir=src/ src/*.lit || exit 1
 fi
 
 # Run cabal

--- a/src/Code.hs
+++ b/src/Code.hs
@@ -1,14 +1,43 @@
+{-# LINE 15 "src/Code.hs.lit" #-}
+{-# LINE 22 "src/Code.hs.lit" #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Code ( generate ) where
+{-# LINE 29 "src/Code.hs.lit" #-}
 import Data.List (partition, intersperse)
 import qualified Data.HashMap.Strict as Map
 import qualified Data.Text as T
 
 import Types
-generate :: [Chunk] -> T.Text
-generate = expand . merge . (filter isDef)
+{-# LINE 44 "src/Code.hs.lit" #-}
+generate :: Bool -> String -> [Chunk] -> T.Text
+generate numberLines ext = expand . merge . numberFn . (filter isDef)
+    where
+        numberFn = if numberLines then (addLineNumbers (getLineGenerator ext)) else id
+{-# LINE 52 "src/Code.hs.lit" #-}
+{-# LINE 60 "src/Code.hs.lit" #-}
+getLineGenerator :: String -> (String -> Int -> T.Text)
+getLineGenerator ".c" = \file line -> T.pack $ "#line " ++ (show line) ++ " \"" ++ file ++ "\"\n"
+getLineGenerator ".hs" = \file line -> T.pack $ "{-# LINE " ++ (show line) ++ " \"" ++ file ++ "\" #-}\n"
+getLineGenerator _ = \file line -> T.pack ""
+{-# LINE 67 "src/Code.hs.lit" #-}
+addLineNumbers :: (String -> Int -> T.Text) -> [Chunk] -> [Chunk]
+addLineNumbers generator chunks = map numberDefs chunks
+    where
+        {-# LINE 76 "src/Code.hs.lit" #-}
+        numberDefs (Def (SourceLoc srcFile srcLine) name parts) =
+            Def (SourceLoc srcFile srcLine) name ((Code (generator srcFile (srcLine + 1))):(numberParts (generator srcFile) (srcLine + 1) parts))
+        numberDefs chunk = chunk
+        {-# LINE 85 "src/Code.hs.lit" #-}
+        numberParts :: (Int -> T.Text) -> Int -> [Part] -> [Part]
+        numberParts mkDirective cLine ((Ref name indent):(Code c):rest) =
+            (Ref name indent):(Code (mkDirective (cLine + 1))):(Code c):(numberParts mkDirective (cLine + 2) rest)
+        numberParts mkDirective cLine (part:rest) =
+            part:(numberParts mkDirective (cLine + 1) rest)
+        numberParts mkDirective cLine [] = []
+{-# LINE 95 "src/Code.hs.lit" #-}
 merge :: [Chunk] -> [Chunk]
 merge = mergeAux []
+{-# LINE 102 "src/Code.hs.lit" #-}
 mergeAux ans [] = ans
 mergeAux ans (next:rest) = 
     let 
@@ -18,6 +47,7 @@ mergeAux ans (next:rest) =
         merged = combineChunks (next:found)
     in 
         mergeAux (merged:ans) rem
+{-# LINE 117 "src/Code.hs.lit" #-}
 combineChunks :: [Chunk] -> Chunk
 combineChunks (a:[]) = a
 combineChunks l@(c:cs) = Def line name parts 
@@ -25,6 +55,7 @@ combineChunks l@(c:cs) = Def line name parts
         parts = concatMap getParts l
         name = getName c
         line = getLineNo c
+{-# LINE 131 "src/Code.hs.lit" #-}
 expand :: [Chunk] -> T.Text
 expand chunks =
     let 
@@ -33,7 +64,8 @@ expand chunks =
         backup = getParts $ last chunks
         parts = Map.lookupDefault backup "*" partMap 
     in
-        expandParts parts partMap T.empty
+        expandParts parts partMap T.empty 
+{-# LINE 147 "src/Code.hs.lit" #-}
 expandParts :: [Part] -> Map.HashMap T.Text [Part] -> T.Text -> T.Text
 expandParts parts partMap baseIndent =
     let 

--- a/src/Code.hs.lit
+++ b/src/Code.hs.lit
@@ -36,20 +36,58 @@ only `Def`. For more information on types see Types.hs
 before calling `generate` to make the code file from a `lit` file. It performs: 
 
 1. Filtering out all `Prose` 
-2. Merging macro definitions with the same name
-3. Expanding macros and references to just lines of code
+2. Adding language-specific line directives
+3. Merging macro definitions with the same name
+4. Expanding macros and references to just lines of code
 
     << generate a code file from chunks >>=
-    generate :: [Chunk] -> T.Text
-    generate = expand . merge . (filter isDef)
+    generate :: Bool -> String -> [Chunk] -> T.Text
+    generate numberLines ext = expand . merge . numberFn . (filter isDef)
+        where
+            numberFn = if numberLines then (addLineNumbers (getLineGenerator ext)) else id
 
 
 `generate` depends on the following helper functions.
     << helper functions >>=
+    << line directive generators >>
+    << add line directives >>
     << merge chunks with the same name >>
     << reduce chunks into one >>
     << expand chunk references with chunks >>
 
+The desired format of the line directives for each supported file type are defined here.
+    << line directive generators >>=
+    getLineGenerator :: String -> (String -> Int -> T.Text)
+    getLineGenerator ".c" = \file line -> T.pack $ "#line " ++ (show line) ++ " \"" ++ file ++ "\"\n"
+    getLineGenerator ".hs" = \file line -> T.pack $ "{-# LINE " ++ (show line) ++ " \"" ++ file ++ "\" #-}\n"
+    getLineGenerator _ = \file line -> T.pack ""
+
+The line directives are inserted into the list of chunks by the `addLineNumbers` function.
+    << add line directives >>=
+    addLineNumbers :: (String -> Int -> T.Text) -> [Chunk] -> [Chunk]
+    addLineNumbers generator chunks = map numberDefs chunks
+        where
+            << number Defs >>
+            << number Parts >>
+
+Each `Def` is prefixed by a line directive, so that when it replaces a reference
+in the output code the line numbers will change appropriately.
+    << number Defs >>=
+    numberDefs (Def (SourceLoc srcFile srcLine) name parts) =
+        Def (SourceLoc srcFile srcLine) name ((Code (generator srcFile (srcLine + 1))):(numberParts (generator srcFile) (srcLine + 1) parts))
+    numberDefs chunk = chunk
+
+Any `Code` part within a `Def` that directly follows a `Ref` part is also
+prefixed with a line directive; so that the line numbering is changed back to
+that of the original `Def` part, rather than continuing incorrectly from the
+code substitued in by the `Ref`.
+    << number Parts >>=
+    numberParts :: (Int -> T.Text) -> Int -> [Part] -> [Part]
+    numberParts mkDirective cLine ((Ref name indent):(Code c):rest) =
+        (Ref name indent):(Code (mkDirective (cLine + 1))):(Code c):(numberParts mkDirective (cLine + 2) rest)
+    numberParts mkDirective cLine (part:rest) =
+        part:(numberParts mkDirective (cLine + 1) rest)
+    numberParts mkDirective cLine [] = []
 
 `merge` allows for a macro extension. By reusing a macro definition,
 narrative can be interweaved into code.
@@ -98,7 +136,7 @@ to the first macro definition, and recursively expands the different parts of th
             backup = getParts $ last chunks
             parts = Map.lookupDefault backup "*" partMap 
         in
-            expandParts parts partMap T.empty
+            expandParts parts partMap T.empty 
 
 `expand` from above relies on `expandParts` to actually perform the recursive lookup. Each
 call to `expandParts` returns text for parts that are simply blocks of code or text which results 

--- a/src/Highlight.hs
+++ b/src/Highlight.hs
@@ -1,4 +1,7 @@
+{-# LINE 13 "src/Highlight.hs.lit" #-}
+{-# LINE 23 "src/Highlight.hs.lit" #-}
 module Highlight (highlight, getLang) where
+{-# LINE 27 "src/Highlight.hs.lit" #-}
 import qualified Data.Text as T 
 import Data.Monoid (mconcat)
 
@@ -9,6 +12,7 @@ import Text.Highlighting.Kate ( defaultFormatOpts
                               , highlightAs
                               , languagesByFilename )
 import Text.Highlighting.Kate.Types 
+{-# LINE 40 "src/Highlight.hs.lit" #-}
 highlight :: String -> T.Text -> H.Html
 highlight lang txt = 
     let
@@ -16,10 +20,12 @@ highlight lang txt =
         htmlList = map sourceLineToHtml highlighted
     in 
         mconcat htmlList
+{-# LINE 50 "src/Highlight.hs.lit" #-}
 sourceLineToHtml :: SourceLine -> H.Html
 sourceLineToHtml line = mconcat $  htmlList ++ [H.toHtml "\n"]
     where
         htmlList = map (tokenToHtml defaultFormatOpts) line
+{-# LINE 57 "src/Highlight.hs.lit" #-}
 tokenToHtml :: FormatOptions -> Token -> H.Html
 tokenToHtml _ (NormalTok, str)  = H.toHtml str
 tokenToHtml opts (toktype, str) =
@@ -27,6 +33,7 @@ tokenToHtml opts (toktype, str) =
     then sp ! A.title (toValue $ show toktype)
     else sp 
         where sp = H.span ! A.class_ (toValue $ short toktype) $ H.toHtml str
+{-# LINE 67 "src/Highlight.hs.lit" #-}
 short :: TokenType -> String
 short KeywordTok        = "kw"
 short DataTypeTok       = "dt"
@@ -42,6 +49,7 @@ short FunctionTok       = "fu"
 short RegionMarkerTok   = "re"
 short ErrorTok          = "er"
 short NormalTok         = ""
+{-# LINE 85 "src/Highlight.hs.lit" #-}
 getLang path = 
     case languagesByFilename path of
     [] -> ""

--- a/src/Html.hs
+++ b/src/Html.hs
@@ -1,5 +1,8 @@
+{-# LINE 12 "src/Html.hs.lit" #-}
+{-# LINE 19 "src/Html.hs.lit" #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Html (generate) where
+{-# LINE 26 "src/Html.hs.lit" #-}
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import Data.Maybe (fromMaybe)
@@ -13,6 +16,7 @@ import Cheapskate.Html
 
 import Highlight
 import Types
+{-# LINE 47 "src/Html.hs.lit" #-}
 generate :: Maybe String -> String -> [Chunk] -> T.Text
 generate maybeCss name chunks = 
     let 
@@ -22,8 +26,11 @@ generate maybeCss name chunks =
         doc = preface maybeCss name body
     in 
         TL.toStrict $ renderHtml doc
+{-# LINE 59 "src/Html.hs.lit" #-}
+{-# LINE 70 "src/Html.hs.lit" #-}
 (<++>) :: T.Text -> T.Text -> T.Text
 (<++>) = T.append
+{-# LINE 77 "src/Html.hs.lit" #-}
 preface :: Maybe String -> String -> H.Html -> H.Html
 preface maybeCss fileName bodyHtml =
     let 
@@ -40,6 +47,7 @@ preface maybeCss fileName bodyHtml =
             H.meta ! A.charset "UTF-8" 
             includeCss
         H.body $ do bodyHtml
+{-# LINE 101 "src/Html.hs.lit" #-}
 simplify :: [Chunk] -> [Chunk]
 simplify [] = []
 simplify lst =
@@ -50,6 +58,7 @@ simplify lst =
     in case ps' of
         [] -> defs ++ rest
         _ -> defs ++ [mergeProse ps'] ++ (simplify rest)
+{-# LINE 117 "src/Html.hs.lit" #-}
 chunkToHtml :: String -> Chunk -> H.Html
 chunkToHtml lang chunk =
     case chunk of
@@ -60,6 +69,7 @@ chunkToHtml lang chunk =
             htmlParts = H.preEscapedToHtml $ map (partToHtml lang) parts
         in 
             H.pre $ H.code $ (header >> htmlParts)
+{-# LINE 132 "src/Html.hs.lit" #-}
 partToHtml :: String -> Part -> H.Html
 partToHtml lang part =
     case part of
@@ -69,12 +79,14 @@ partToHtml lang part =
             link = "<a href=\"#" <++> underscored <++> "\">" <++> slim <++> "</a>"
             slim = T.strip txt
             underscored = underscore slim 
+{-# LINE 146 "src/Html.hs.lit" #-}
 headerToHtml :: T.Text -> H.Html
 headerToHtml name =  H.preEscapedToHtml $ "&lt;&lt; " <++> link <++> " &gt;&gt;=\n" 
     where
         link = "<a id=\"" <++> underscored <++> "\" href=\"#" <++> underscored <++> "\">" <++> slim <++> "</a>"
         slim = T.strip name
         underscored = underscore slim
+{-# LINE 157 "src/Html.hs.lit" #-}
 underscore :: T.Text -> T.Text
 underscore txt =
     T.pack $ concatMap (\c -> if c == ' ' then "_" else [c]) $ T.unpack txt

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -1,9 +1,13 @@
+{-# LINE 13 "src/Markdown.hs.lit" #-}
+{-# LINE 20 "src/Markdown.hs.lit" #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Markdown ( generate ) where
+{-# LINE 26 "src/Markdown.hs.lit" #-}
 import qualified Data.Text as T
 
 import Types
 import Highlight (getLang)
+{-# LINE 35 "src/Markdown.hs.lit" #-}
 generate :: String -> [Chunk] -> T.Text
 generate name chunks = 
     let 
@@ -11,8 +15,11 @@ generate name chunks =
         toMarkDown = chunkToMarkdown lang
     in
         T.concat $ map toMarkDown chunks
+{-# LINE 46 "src/Markdown.hs.lit" #-}
+{-# LINE 53 "src/Markdown.hs.lit" #-}
 (<++>) :: T.Text -> T.Text -> T.Text
 (<++>) = T.append
+{-# LINE 60 "src/Markdown.hs.lit" #-}
 chunkToMarkdown lang chunk =
     case chunk of
     Prose text  -> text
@@ -25,6 +32,7 @@ chunkToMarkdown lang chunk =
             "```" <++> lang'   <++> 
             "\n"  <++> header  <++> 
             "\n"  <++> mdParts <++> "```\n"
+{-# LINE 79 "src/Markdown.hs.lit" #-}
 partToText :: String -> Part -> T.Text
 partToText lang part =
     case part of

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -1,34 +1,46 @@
+{-# LINE 17 "src/Parse.hs.lit" #-}
+{-# LINE 26 "src/Parse.hs.lit" #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Parse where
+{-# LINE 31 "src/Parse.hs.lit" #-}
 import Text.Parsec
 import Text.Parsec.Text
 import qualified Data.Text as T
 
 import Types
+{-# LINE 39 "src/Parse.hs.lit" #-}
 encode :: T.Text -> String -> [Chunk]
 encode txt fileName =
     case (parse entire fileName txt) of 
     Left err -> []
     Right result -> result
+{-# LINE 47 "src/Parse.hs.lit" #-}
+{-# LINE 63 "src/Parse.hs.lit" #-}
 entire :: Parser Program
 entire = manyTill chunk eof
+{-# LINE 68 "src/Parse.hs.lit" #-}
 chunk :: Parser Chunk
 chunk = (try def) <|> (try include) <|> prose
+{-# LINE 73 "src/Parse.hs.lit" #-}
 prose :: Parser Chunk
 prose = grabLine >>= (\line -> return $ Prose line)
+{-# LINE 82 "src/Parse.hs.lit" #-}
 include :: Parser Chunk
 include = do
     pos <- getPosition
     indent <- many ws
     fileName <- packM =<< between (string ">>") (string "<<") (many $ noneOf "<")
     return $ Include (sourceName pos) $ T.strip fileName
+{-# LINE 92 "src/Parse.hs.lit" #-}
 def :: Parser Chunk
 def = do
     (indent, header, pos) <- title
     parts <- manyTill (part indent) $ endDef indent
     return $ Def (SourceLoc (sourceName pos) (sourceLine pos)) header parts
+{-# LINE 103 "src/Parse.hs.lit" #-}
 endDef :: String -> Parser ()
 endDef indent = try $ do { skipMany newline; notFollowedBy (string indent) <|> (lookAhead title >> parserReturn ()) }
+{-# LINE 109 "src/Parse.hs.lit" #-}
 -- Returns (indent, macro-name, line-no)
 title :: Parser (String, T.Text, SourcePos)
 title = do
@@ -37,30 +49,38 @@ title = do
     name <- packM =<< between (string "<<") (string ">>=") (many notDelim)
     newline
     return $ (indent, T.strip name, pos)
+{-# LINE 120 "src/Parse.hs.lit" #-}
 notDelim = noneOf ">="
+{-# LINE 125 "src/Parse.hs.lit" #-}
 part :: String -> Parser Part
 part indent = 
     try (string indent >> varLine) <|> 
     try (string indent >> defLine) <|>
     (grabLine >>= \extra -> return $ Code extra)
+{-# LINE 133 "src/Parse.hs.lit" #-}
 varLine :: Parser Part
 varLine = do
     indent <- packM =<< many ws
     name <- packM =<< between (string "<<") (string ">>") (many notDelim)
     newline
     return $ Ref name indent
+{-# LINE 142 "src/Parse.hs.lit" #-}
 defLine :: Parser Part
 defLine = do
     line <- grabLine
     return $ Code line
+{-# LINE 149 "src/Parse.hs.lit" #-}
 grabLine :: Parser T.Text
 grabLine = do 
     line <- many (noneOf "\n\r")
     last <- newline
     return $ T.pack $ line ++ [last]
+{-# LINE 157 "src/Parse.hs.lit" #-}
 ws :: Parser Char
 ws = char ' ' <|> char '\t'
+{-# LINE 162 "src/Parse.hs.lit" #-}
 packM str = return $ T.pack str
+{-# LINE 166 "src/Parse.hs.lit" #-}
 textP :: Parsec T.Text () T.Text ->  T.Text -> T.Text
 textP p txt =
     case (parse p "" txt) of 

--- a/src/Parse.hs.lit
+++ b/src/Parse.hs.lit
@@ -36,9 +36,9 @@ For the sake of testing, parse exports all of its definitions.
 
 `encode` is the primary function of Parse. It interfaces between Process and the various pipelines which interpret the `[Chunk]` into various outputs.
     << lit file to data structure >>=
-    encode :: T.Text -> [Chunk]
-    encode txt =
-        case (parse entire "" txt) of 
+    encode :: T.Text -> String -> [Chunk]
+    encode txt fileName =
+        case (parse entire fileName txt) of 
         Left err -> []
         Right result -> result
 
@@ -47,6 +47,7 @@ These are the many parsers from generic to most specific, which collectively par
     << parse all the chunks >>
     << parse a chunk >>
     << parse a chunk of prose >>
+    << parse an include directive >>
     << parse a chunk definition >>
     << try parsing the end of a definition >>
     << parse the title of a definiton >>
@@ -62,24 +63,37 @@ Parse all the chunks until the end of the file
     entire :: Parser Program
     entire = manyTill chunk eof
 
-Parse a chunk which is either of type `Def` or type `Prose`
+Parse a chunk which is either of type `Def`, `Include`, or `Prose`
     << parse a chunk >>=
     chunk :: Parser Chunk
-    chunk = (try def) <|> prose
+    chunk = (try def) <|> (try include) <|> prose
 
 Parse a line of prose, return `Prose` container of the line.
     << parse a chunk of prose >>=
     prose :: Parser Chunk
     prose = grabLine >>= (\line -> return $ Prose line)
 
+Parse an include directive, which looks like `>> filename <<`. Currently
+whitespace is stripped from the start and end of the filename in the same way as
+definition names. This means that you can't include files which have names that
+start or end in whitespace. The parser is not actually responsible for reading
+in the included file - that is performed in the `Process` module.
+    << parse an include directive >>=
+    include :: Parser Chunk
+    include = do
+        pos <- getPosition
+        indent <- many ws
+        fileName <- packM =<< between (string ">>") (string "<<") (many $ noneOf "<")
+        return $ Include (sourceName pos) $ T.strip fileName
+
 Parse a definiton of type `Def` by parsing the title
 and parsing the subparts (lines of code or references to chunks)
     << parse a chunk definition >>=
     def :: Parser Chunk
     def = do
-        (indent, header, lineNum) <- title
+        (indent, header, pos) <- title
         parts <- manyTill (part indent) $ endDef indent
-        return $ Def lineNum header parts
+        return $ Def (SourceLoc (sourceName pos) (sourceLine pos)) header parts
 
 A parser which *tries* does not consume input if it fails. `endDef` succeeds
 when the indentation does not match the proper indentation, or when there is
@@ -93,13 +107,13 @@ Parse the line which gives a title to a code chunk. `title` returns unique outpu
 to be used later. Ex. it records the indent, to match agains the body it contains.
     << parse the title of a definiton >>=
     -- Returns (indent, macro-name, line-no)
-    title :: Parser (String, T.Text, Int)
+    title :: Parser (String, T.Text, SourcePos)
     title = do
         pos <- getPosition
         indent <- many ws
         name <- packM =<< between (string "<<") (string ">>=") (many notDelim)
         newline
-        return $ (indent, T.strip name, sourceLine pos)
+        return $ (indent, T.strip name, pos)
 
 Parse a character which could lie within a title.
     << parse inside of title >>=

--- a/src/Poll.hs
+++ b/src/Poll.hs
@@ -1,11 +1,15 @@
+{-# LINE 7 "src/Poll.hs.lit" #-}
+{-# LINE 15 "src/Poll.hs.lit" #-}
 module Poll 
 ( watch ) where
+{-# LINE 19 "src/Poll.hs.lit" #-}
 import System.Directory
 import Data.Time.Clock
 import Data.Time.Calendar
 import Control.Monad (forever)
 import qualified Control.Concurrent as C
 import System.IO.Error
+{-# LINE 30 "src/Poll.hs.lit" #-}
 watch :: (String -> IO ()) -> [String] -> IO ()
 watch fun fs = 
     let 
@@ -14,12 +18,14 @@ watch fun fs =
     putStrLn "starting.."
     mapM_ fun fs
     forever $ (wait >> mapM_ (onChange fun) fs)
+{-# LINE 43 "src/Poll.hs.lit" #-}
 onChange :: (String -> IO ()) -> String -> IO ()
 onChange fun file = do
     modified <- retryAtMost 10 (getModificationTime file) 
     curTime <- getCurrentTime 
     let diff = (diffUTCTime curTime modified)
     if diff < 2 then fun file else return ()
+{-# LINE 55 "src/Poll.hs.lit" #-}
 retryAtMost 1 action = catchIOError action (\e -> ioError e)
 retryAtMost times action = 
     let

--- a/src/Process.hs
+++ b/src/Process.hs
@@ -1,12 +1,15 @@
+{-# LINE 11 "src/Process.hs.lit" #-}
+{-# LINE 19 "src/Process.hs.lit" #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Process
 ( process
 , htmlPipeline
 , mdPipeline
 , codePipeline ) where
+{-# LINE 28 "src/Process.hs.lit" #-}
 import Prelude hiding (readFile, writeFile)
 import Data.Text.IO (writeFile, readFile)
-import System.FilePath.Posix (takeFileName, dropExtension, combine)
+import System.FilePath.Posix (takeFileName, dropExtension, combine, takeExtension)
 import System.Directory
 import System.FilePath.Posix
 import Data.List (intercalate)
@@ -17,6 +20,7 @@ import Code
 import Html
 import Markdown
 import Types
+{-# LINE 44 "src/Process.hs.lit" #-}
 process pipes file = do 
     encoded <- encodeFile file
     mapM_ (\f -> f fileName encoded) pipes >> return ()
@@ -27,6 +31,7 @@ encodeFile :: String -> IO [Chunk]
 encodeFile file = do
     stream <- readFile file
     expandInclude $ encode stream file
+{-# LINE 59 "src/Process.hs.lit" #-}
 expandInclude :: [Chunk] -> IO [Chunk]
 expandInclude ((Include sourceName includedName):rest) = do
     tail <- expandInclude rest
@@ -40,19 +45,24 @@ expandInclude (chunk:rest) = do
     return $ chunk:tail
 
 expandInclude [] = return []
-htmlPipeline dir mCss name enc = do
+{-# LINE 80 "src/Process.hs.lit" #-}
+{-# LINE 86 "src/Process.hs.lit" #-}
+htmlPipeline dir mCss numberLines name enc = do
     maybeCss <- cssRelativeToOutput dir mCss
     let path = (addTrailingPathSeparator dir) ++ name ++ ".html"
         output = Html.generate maybeCss name enc
     writeFile path output
-mdPipeline dir css name enc = writeFile path output
+{-# LINE 93 "src/Process.hs.lit" #-}
+mdPipeline dir css numberLines name enc = writeFile path output
     where
         path = (addTrailingPathSeparator dir) ++ name ++ ".md"
         output = Markdown.generate name enc
-codePipeline dir css name enc = writeFile path output
+{-# LINE 99 "src/Process.hs.lit" #-}
+codePipeline dir css numberLines name enc = writeFile path output
     where
         path = (addTrailingPathSeparator dir) ++ name
-        output = Code.generate enc
+        output = Code.generate numberLines (takeExtension name) enc
+{-# LINE 107 "src/Process.hs.lit" #-}
 cssRelativeToOutput :: String -> Maybe String -> IO (Maybe String)
 cssRelativeToOutput output mCss =
     case mCss of

--- a/src/Process.hs.lit
+++ b/src/Process.hs.lit
@@ -11,6 +11,7 @@ An overview of the file:
     << define Process module >>
     << import modules >>
     << process a single file >>
+    << expand includes >>
     << helper functions >>
 
 Process exports the pipelines so they can be *preconfigured*. In `lit.hs`, the pipelines are curried with the output directory corresponding to their type, and with the optional css path. The `process` function depends on being called with preconfigured pipes.     
@@ -26,7 +27,7 @@ Besides the reading and writing file utilities, each output format is contained 
     << import modules >>=
     import Prelude hiding (readFile, writeFile)
     import Data.Text.IO (writeFile, readFile)
-    import System.FilePath.Posix (takeFileName, dropExtension)
+    import System.FilePath.Posix (takeFileName, dropExtension, combine)
     import System.Directory
     import System.FilePath.Posix
     import Data.List (intercalate)
@@ -41,11 +42,33 @@ Besides the reading and writing file utilities, each output format is contained 
 Process as a library accompolishes the primary goals through the `process` function. After reading the file, `encode` parses the file into `[Chunks]` (see [Types.hs](Types.hs.html) for more about the data structure). Lastly, each pipeline function in the list of `pipes` is applied to the data structure. Each pipeline takes a `[Chunks]` and writes a file. 
     << process a single file >>=
     process pipes file = do 
-        stream <- readFile file
-        encoded <- return $ encode stream 
+        encoded <- encodeFile file
         mapM_ (\f -> f fileName encoded) pipes >> return ()
         where
             fileName = dropExtension $ takeFileName file
+
+    encodeFile :: String -> IO [Chunk]
+    encodeFile file = do
+        stream <- readFile file
+        expandInclude $ encode stream file
+
+The parser generates `Include` chunks when an include directive is seen in the
+input. This function recursively expands those `Include` chunks by parsing the
+included file and splicing in the chunks parsed.
+    << expand includes >>=
+    expandInclude :: [Chunk] -> IO [Chunk]
+    expandInclude ((Include sourceName includedName):rest) = do
+        tail <- expandInclude rest
+        encodedInclude <- encodeFile includedFile
+        return $ encodedInclude ++ tail
+        where
+            includedFile = combine (dropFileName sourceName) $ T.unpack includedName
+
+    expandInclude (chunk:rest) = do
+        tail <- expandInclude rest
+        return $ chunk:tail
+
+    expandInclude [] = return []
 
 Beside the main function `process`. Process as a module defines several useful pipelines (function transforms chained together). Each pipeline can be generalized in the following way.
 

--- a/src/Process.hs.lit
+++ b/src/Process.hs.lit
@@ -27,7 +27,7 @@ Besides the reading and writing file utilities, each output format is contained 
     << import modules >>=
     import Prelude hiding (readFile, writeFile)
     import Data.Text.IO (writeFile, readFile)
-    import System.FilePath.Posix (takeFileName, dropExtension, combine)
+    import System.FilePath.Posix (takeFileName, dropExtension, combine, takeExtension)
     import System.Directory
     import System.FilePath.Posix
     import Data.List (intercalate)
@@ -83,23 +83,23 @@ Beside the main function `process`. Process as a module defines several useful p
     << html helpers >>
 
     << html pipeline >>=
-    htmlPipeline dir mCss name enc = do
+    htmlPipeline dir mCss numberLines name enc = do
         maybeCss <- cssRelativeToOutput dir mCss
         let path = (addTrailingPathSeparator dir) ++ name ++ ".html"
             output = Html.generate maybeCss name enc
         writeFile path output
 
     << markdown pipeline >>=
-    mdPipeline dir css name enc = writeFile path output
+    mdPipeline dir css numberLines name enc = writeFile path output
         where
             path = (addTrailingPathSeparator dir) ++ name ++ ".md"
             output = Markdown.generate name enc
 
     << code pipeline >>=
-    codePipeline dir css name enc = writeFile path output
+    codePipeline dir css numberLines name enc = writeFile path output
         where
             path = (addTrailingPathSeparator dir) ++ name
-            output = Code.generate enc
+            output = Code.generate numberLines (takeExtension name) enc
 
 The helpers below take a path to a css file and a path to an html file
 from the current directory and return the path linking the html to the css.

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,12 +1,14 @@
 module Types where
 
 import Data.Text 
-data Chunk = Def Int Text [Part] | Prose Text deriving (Show, Eq)
+data SourceLoc = SourceLoc String Int deriving (Show, Eq)
+data Chunk = Def SourceLoc Text [Part] | Include String Text | Prose Text deriving (Show, Eq)
 data Part = Code Text | Ref Text Text deriving (Show, Eq)
 type Program = [Chunk]
 isDef chunk =
     case chunk of
     Def _ _ _ -> True
+    Include _ _ -> False
     Prose _ -> False
 isRef part =
     case part of

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,35 +1,45 @@
+{-# LINE 7 "src/Types.hs.lit" #-}
+{-# LINE 14 "src/Types.hs.lit" #-}
 module Types where
 
 import Data.Text 
+{-# LINE 26 "src/Types.hs.lit" #-}
 data SourceLoc = SourceLoc String Int deriving (Show, Eq)
 data Chunk = Def SourceLoc Text [Part] | Include String Text | Prose Text deriving (Show, Eq)
 data Part = Code Text | Ref Text Text deriving (Show, Eq)
 type Program = [Chunk]
+{-# LINE 33 "src/Types.hs.lit" #-}
 isDef chunk =
     case chunk of
     Def _ _ _ -> True
     Include _ _ -> False
     Prose _ -> False
+{-# LINE 41 "src/Types.hs.lit" #-}
 isRef part =
     case part of
     Ref _ _ -> True
     _ -> False
+{-# LINE 48 "src/Types.hs.lit" #-}
 getName chunk =
     case chunk of
     Def _ name _ -> name
     _ -> error "cannot retrieve name, not a def"
+{-# LINE 55 "src/Types.hs.lit" #-}
 getCodeText part = 
     case part of
     Code txt -> txt
     _ -> error "cannot retrieve text, not a code part"
+{-# LINE 63 "src/Types.hs.lit" #-}
 getParts chunk =
     case chunk of
     Def _ _ parts -> parts
     _ -> error "cannot retrieve parts, not a def"
+{-# LINE 71 "src/Types.hs.lit" #-}
 getLineNo chunk =
     case chunk of
     Def line _ _ -> line
     _ -> error "cannot retrieve line number, not a def"
+{-# LINE 78 "src/Types.hs.lit" #-}
 getProseText chunk = 
     case chunk of
     Prose txt -> txt

--- a/src/Types.hs.lit
+++ b/src/Types.hs.lit
@@ -23,7 +23,8 @@ The `Def` constructor represents the code chunk, storing the line no. and chunk 
 Each code chunk  stores a `[Part]`, which represent lines of code or macro references
 of the form `<< name >>`.
     << datatypes >>=
-    data Chunk = Def Int Text [Part] | Prose Text deriving (Show, Eq)
+    data SourceLoc = SourceLoc String Int deriving (Show, Eq)
+    data Chunk = Def SourceLoc Text [Part] | Include String Text | Prose Text deriving (Show, Eq)
     data Part = Code Text | Ref Text Text deriving (Show, Eq)
     type Program = [Chunk]
 
@@ -32,6 +33,7 @@ A boolean check to differentiate between a `Prose` or `Def` chunk.
     isDef chunk =
         case chunk of
         Def _ _ _ -> True
+        Include _ _ -> False
         Prose _ -> False
 
 A boolean check to differentiate between a `Ref` or `Code` part.

--- a/src/lit.hs
+++ b/src/lit.hs
@@ -1,3 +1,5 @@
+{-# LINE 7 "src/lit.hs.lit" #-}
+{-# LINE 14 "src/lit.hs.lit" #-}
 module Main where
 
 import System.Console.GetOpt
@@ -9,6 +11,8 @@ import Control.Applicative
 
 import Process
 import Poll
+{-# LINE 29 "src/lit.hs.lit" #-}
+{-# LINE 35 "src/lit.hs.lit" #-}
 data Options = Options  { optCodeDir  :: String 
                         , optDocsDir  :: String
                         , optCss      :: Maybe String
@@ -16,7 +20,9 @@ data Options = Options  { optCodeDir  :: String
                         , optHtml     :: Bool
                         , optMarkdown :: Bool
                         , optWatch    :: Bool
+                        , optNumber   :: Bool
                         }
+{-# LINE 46 "src/lit.hs.lit" #-}
 startOptions :: Options
 startOptions = Options  { optCodeDir  = "./"
                         , optDocsDir  = "./"
@@ -25,7 +31,9 @@ startOptions = Options  { optCodeDir  = "./"
                         , optHtml     = False
                         , optMarkdown = False
                         , optWatch    = False
+                        , optNumber   = False
                         }
+{-# LINE 59 "src/lit.hs.lit" #-}
 options :: [ OptDescr (Options -> IO Options) ]
 options = 
     [ Option  "h" ["html"]
@@ -39,6 +47,10 @@ options =
     , Option "c" ["code"]
        (NoArg (\opt -> return opt { optCode = True }))
        "Generate code by file extension"
+
+    , Option "n" ["number"]
+       (NoArg (\opt -> return opt { optNumber = True }))
+       "Add annotations to generated code noting the lit file and line from which it came"
 
     , Option "" ["css"]
        (ReqArg
@@ -78,13 +90,16 @@ options =
                exitWith ExitSuccess))
        "Display help"
     ]
+{-# LINE 118 "src/lit.hs.lit" #-}
 usage = "Usage: lit OPTIONS... FILES..."
 help = "Try:   lit --help"
+{-# LINE 123 "src/lit.hs.lit" #-}
 main = do
     args <- getArgs
  
     -- Parse options, getting a list of option actions
     let (actions, files, errors) = getOpt Permute options args
+{-# LINE 131 "src/lit.hs.lit" #-}
     opts <- foldl (>>=) (return startOptions) actions
  
     let Options { optCodeDir  = codeDir
@@ -94,17 +109,21 @@ main = do
                 , optHtml     = html
                 , optCss      = mCss
                 , optWatch    = watching
+                , optNumber   = numberLines
                 } = opts 
+{-# LINE 145 "src/lit.hs.lit" #-}
     codeDirCheck <- doesDirectoryExist codeDir
     docsDirCheck <- doesDirectoryExist docsDir
-    let htmlPipe = if html     then [Process.htmlPipeline docsDir mCss] else []
-        mdPipe   = if markdown then [Process.mdPipeline   docsDir mCss] else []
-        codePipe = if code     then [Process.codePipeline codeDir mCss] else []
+{-# LINE 150 "src/lit.hs.lit" #-}
+    let htmlPipe = if html     then [Process.htmlPipeline docsDir mCss numberLines] else []
+        mdPipe   = if markdown then [Process.mdPipeline   docsDir mCss numberLines] else []
+        codePipe = if code     then [Process.codePipeline codeDir mCss numberLines] else []
         pipes = htmlPipe ++ mdPipe ++ codePipe 
         maybeWatch = if watching then Poll.watch else mapM_
         errors'  = if codeDirCheck then [] else ["Directory: " ++ codeDir ++ " does not exist\n"]
         errors'' = if docsDirCheck then [] else ["Directory: " ++ docsDir ++ " does not exist\n"]
         allErr = errors ++ errors' ++ errors''
+{-# LINE 161 "src/lit.hs.lit" #-}
     if allErr /= [] || (not html && not code && not markdown) || files == []
         then hPutStrLn stderr ((concat allErr) ++ help) 
         else (maybeWatch (Process.process pipes)) files

--- a/src/lit.hs.lit
+++ b/src/lit.hs.lit
@@ -39,6 +39,7 @@ A high-level overview of `lit.hs`:
                             , optHtml     :: Bool
                             , optMarkdown :: Bool
                             , optWatch    :: Bool
+                            , optNumber   :: Bool
                             }
 
     << default options >>=
@@ -50,6 +51,7 @@ A high-level overview of `lit.hs`:
                             , optHtml     = False
                             , optMarkdown = False
                             , optWatch    = False
+                            , optNumber   = False
                             }
 
 `options` is a list of monadic functions, which are applied to the options passed as arguments to `lit`. `options` provides the general program flow for argument handling.
@@ -67,6 +69,10 @@ A high-level overview of `lit.hs`:
         , Option "c" ["code"]
            (NoArg (\opt -> return opt { optCode = True }))
            "Generate code by file extension"
+    
+        , Option "n" ["number"]
+           (NoArg (\opt -> return opt { optNumber = True }))
+           "Add annotations to generated code noting the lit file and line from which it came"
     
         , Option "" ["css"]
            (ReqArg
@@ -131,6 +137,7 @@ After interpreting the arguments, `foldl` threads the default options through ea
                     , optHtml     = html
                     , optCss      = mCss
                     , optWatch    = watching
+                    , optNumber   = numberLines
                     } = opts 
 
 A brief check to ensure that the directories actually exist for the given strings. This prevents ambiguous errors about writing to invalid paths.
@@ -140,9 +147,9 @@ A brief check to ensure that the directories actually exist for the given string
 
 Based on the conditions, we prepare part of the pipeline (the rest occurs in Process.hs) for generating (html/markdown/code). This block aims to gather all the pipes and program errors necessary for determining whether to process or exit. `maybeWatch` determines whether the files should be directly passed through the pipes via `mapM_` or whether `Poll.watch` should manage the pipelines whenever the underlying files change.
     << main >>=
-        let htmlPipe = if html     then [Process.htmlPipeline docsDir mCss] else []
-            mdPipe   = if markdown then [Process.mdPipeline   docsDir mCss] else []
-            codePipe = if code     then [Process.codePipeline codeDir mCss] else []
+        let htmlPipe = if html     then [Process.htmlPipeline docsDir mCss numberLines] else []
+            mdPipe   = if markdown then [Process.mdPipeline   docsDir mCss numberLines] else []
+            codePipe = if code     then [Process.codePipeline codeDir mCss numberLines] else []
             pipes = htmlPipe ++ mdPipe ++ codePipe 
             maybeWatch = if watching then Poll.watch else mapM_
             errors'  = if codeDirCheck then [] else ["Directory: " ++ codeDir ++ " does not exist\n"]


### PR DESCRIPTION
This is two changes which I've actually been using for a while - they probably need some tidying but would you consider them for upstream inclusion in principle? I know you are trying to keep `lit` simple and clean.

I'm developing a C library (~3000 lines), and I need to generate a `.c` and `.h` file but want to keep the vast majority of the exposition shared in a single lit file. This is included into both the `.c.lit` and `.h.lit` files.