### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#lit - a *modern* literate programming tool
+# lit - a *modern* literate programming tool
 
 ## What is literate programming?
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,13 +1,13 @@
-##To run output tests
+## To run output tests
 `../scripts/test.sh`
 
-##To add output tests
+## To add output tests
 Add two files: issue42, issue42.lit. Where issue42 is the desired output of
 issue42.lit. 
 
-##A test failed!
+## A test failed!
 test.sh will create a results directory where errors are
 reported as diffs of what was expected. 
 
-##Run haskell tests
+## Run haskell tests
 `ghc -i../src/ Tests.hs -e 'Tests.main'`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
